### PR TITLE
build: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./parser_server.py" ]


### PR DESCRIPTION
Allows the tlds API server to start up the parser gRPC as a Docker
Compose service that can run alongside the local development server.