### PR TITLE
feat(proto): Use repeated fields

### DIFF
--- a/parser.pb.go
+++ b/parser.pb.go
@@ -23,7 +23,8 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type ParseRequest struct {
-	Pages                string   `protobuf:"bytes,1,opt,name=pages,proto3" json:"pages,omitempty"`
+	// The pages to parse into paragraphs.
+	Pages                []string `protobuf:"bytes,1,rep,name=pages,proto3" json:"pages,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -54,15 +55,16 @@ func (m *ParseRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ParseRequest proto.InternalMessageInfo
 
-func (m *ParseRequest) GetPages() string {
+func (m *ParseRequest) GetPages() []string {
 	if m != nil {
 		return m.Pages
 	}
-	return ""
+	return nil
 }
 
 type ParseReply struct {
-	Text                 string   `protobuf:"bytes,1,opt,name=text,proto3" json:"text,omitempty"`
+	// The list of important paragraphs from parsing all of the pages.
+	Paragraphs           []string `protobuf:"bytes,1,rep,name=paragraphs,proto3" json:"paragraphs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -93,11 +95,11 @@ func (m *ParseReply) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ParseReply proto.InternalMessageInfo
 
-func (m *ParseReply) GetText() string {
+func (m *ParseReply) GetParagraphs() []string {
 	if m != nil {
-		return m.Text
+		return m.Paragraphs
 	}
-	return ""
+	return nil
 }
 
 func init() {
@@ -108,16 +110,15 @@ func init() {
 func init() { proto.RegisterFile("parser.proto", fileDescriptor_128ea0fcf29414eb) }
 
 var fileDescriptor_128ea0fcf29414eb = []byte{
-	// 134 bytes of a gzipped FileDescriptorProto
+	// 127 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x29, 0x48, 0x2c, 0x2a,
 	0x4e, 0x2d, 0xd2, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x57, 0x52, 0xe1, 0xe2, 0x09, 0x00, 0xf1, 0x83,
 	0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b, 0x84, 0x44, 0xb8, 0x58, 0x0b, 0x12, 0xd3, 0x53, 0x8b, 0x25,
-	0x18, 0x15, 0x18, 0x35, 0x38, 0x83, 0x20, 0x1c, 0x25, 0x05, 0x2e, 0x2e, 0xa8, 0xaa, 0x82, 0x9c,
-	0x4a, 0x21, 0x21, 0x2e, 0x96, 0x92, 0xd4, 0x8a, 0x12, 0xa8, 0x12, 0x30, 0xdb, 0xc8, 0x86, 0x8b,
-	0xdf, 0x27, 0x35, 0x37, 0x33, 0x27, 0x27, 0x33, 0x3f, 0x0f, 0xac, 0xb4, 0x48, 0x48, 0x93, 0x8b,
-	0x13, 0x6c, 0x95, 0x4b, 0x62, 0x49, 0xa2, 0x10, 0xaf, 0x1e, 0xb2, 0x35, 0x52, 0xdc, 0x7a, 0x08,
-	0xf3, 0x94, 0x18, 0x92, 0xd8, 0xc0, 0x8e, 0x31, 0x06, 0x04, 0x00, 0x00, 0xff, 0xff, 0x5e, 0x95,
-	0x14, 0x63, 0x9c, 0x00, 0x00, 0x00,
+	0x18, 0x15, 0x98, 0x35, 0x38, 0x83, 0x20, 0x1c, 0x25, 0x1d, 0x2e, 0x2e, 0xa8, 0xaa, 0x82, 0x9c,
+	0x4a, 0x21, 0x39, 0x2e, 0xae, 0x82, 0xc4, 0xa2, 0xc4, 0xf4, 0xa2, 0xc4, 0x82, 0x0c, 0x98, 0x42,
+	0x24, 0x11, 0x23, 0x7d, 0x2e, 0x36, 0xb0, 0xea, 0x22, 0x21, 0x55, 0x90, 0x69, 0x45, 0xc5, 0xa9,
+	0x42, 0xbc, 0x7a, 0xc8, 0xb6, 0x48, 0x71, 0xeb, 0x21, 0x8c, 0x53, 0x62, 0x48, 0x62, 0x03, 0xbb,
+	0xc5, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff, 0xa4, 0xc1, 0xc3, 0xf9, 0x9b, 0x00, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -128,64 +129,66 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// LemillionParserClient is the client API for LemillionParser service.
+// ParserClient is the client API for Parser service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
-type LemillionParserClient interface {
-	ParseData(ctx context.Context, in *ParseRequest, opts ...grpc.CallOption) (*ParseReply, error)
+type ParserClient interface {
+	// Parse several pages and return the important paragraphs.
+	Parse(ctx context.Context, in *ParseRequest, opts ...grpc.CallOption) (*ParseReply, error)
 }
 
-type lemillionParserClient struct {
+type parserClient struct {
 	cc *grpc.ClientConn
 }
 
-func NewLemillionParserClient(cc *grpc.ClientConn) LemillionParserClient {
-	return &lemillionParserClient{cc}
+func NewParserClient(cc *grpc.ClientConn) ParserClient {
+	return &parserClient{cc}
 }
 
-func (c *lemillionParserClient) ParseData(ctx context.Context, in *ParseRequest, opts ...grpc.CallOption) (*ParseReply, error) {
+func (c *parserClient) Parse(ctx context.Context, in *ParseRequest, opts ...grpc.CallOption) (*ParseReply, error) {
 	out := new(ParseReply)
-	err := c.cc.Invoke(ctx, "/LemillionParser/parseData", in, out, opts...)
+	err := c.cc.Invoke(ctx, "/Parser/parse", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// LemillionParserServer is the server API for LemillionParser service.
-type LemillionParserServer interface {
-	ParseData(context.Context, *ParseRequest) (*ParseReply, error)
+// ParserServer is the server API for Parser service.
+type ParserServer interface {
+	// Parse several pages and return the important paragraphs.
+	Parse(context.Context, *ParseRequest) (*ParseReply, error)
 }
 
-func RegisterLemillionParserServer(s *grpc.Server, srv LemillionParserServer) {
-	s.RegisterService(&_LemillionParser_serviceDesc, srv)
+func RegisterParserServer(s *grpc.Server, srv ParserServer) {
+	s.RegisterService(&_Parser_serviceDesc, srv)
 }
 
-func _LemillionParser_ParseData_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Parser_Parse_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ParseRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(LemillionParserServer).ParseData(ctx, in)
+		return srv.(ParserServer).Parse(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/LemillionParser/ParseData",
+		FullMethod: "/Parser/Parse",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(LemillionParserServer).ParseData(ctx, req.(*ParseRequest))
+		return srv.(ParserServer).Parse(ctx, req.(*ParseRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-var _LemillionParser_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "LemillionParser",
-	HandlerType: (*LemillionParserServer)(nil),
+var _Parser_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "Parser",
+	HandlerType: (*ParserServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "parseData",
-			Handler:    _LemillionParser_ParseData_Handler,
+			MethodName: "parse",
+			Handler:    _Parser_Parse_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/parser.proto
+++ b/parser.proto
@@ -1,18 +1,18 @@
 syntax = "proto3";
 
-message ParseRequest{
-
-    string pages = 1;
-
+// The parser service takes several results from Microsoft OCR and performs
+// clustering to determine which parts are important.
+service Parser {
+  // Parse several pages and return the important paragraphs.
+  rpc parse(ParseRequest) returns (ParseReply) {}
 }
 
-message ParseReply{
-
-    string text = 1;
-
+message ParseRequest {
+  // The pages to parse into paragraphs.
+  repeated string pages = 1;
 }
 
-service LemillionParser{
-
-    rpc parseData(ParseRequest) returns (ParseReply) {}
+message ParseReply {
+  // The list of important paragraphs from parsing all of the pages.
+  repeated string paragraphs = 1;
 }

--- a/parser.proto
+++ b/parser.proto
@@ -8,8 +8,8 @@ service Parser {
 }
 
 message ParseRequest {
-  // The pages to parse into paragraphs.
-  repeated string pages = 1;
+  // The pages, formatted in JSON, to parse into paragraphs.
+  repeated string pagesJSON = 1;
 }
 
 message ParseReply {


### PR DESCRIPTION
The use of repeated fields allows for supplying an array field, instead
of having to pass JSON everywhere. This will also make encoding and
decoding really fast on both client and server.

This change also renames the service to be shorter. Comments were
added for documentation when the Go client is generated.